### PR TITLE
dist/debian: allow building non-amd64 .deb

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Rules-Requires-Root: no
 
 Package: %{product}-python3
-Architecture: amd64
+Architecture: any
 Description: A standalone python3 interpreter that can be moved around different Linux machines
  This is a self-contained python interpreter that can be moved around
  different Linux machines as long as they run a new enough kernel (where


### PR DESCRIPTION
Allow building .deb on any architecture, not only amd64.