### PR TITLE
reloc: add --clean and --nodeps options for compatibility

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# TODO: move python dependencies from scylla main repo

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -23,9 +23,13 @@
 print_usage() {
     echo "build_reloc.sh --dest build/scylla-python3-package.tar.gz"
     echo "  --dest specify destination path"
+    echo "  --clean clean build directory"
+    echo "  --nodeps    skip installing dependencies"
     exit 1
 }
 
+CLEAN=
+NODEPS=
 DEST=build/scylla-python3-package.tar.gz
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -33,14 +37,26 @@ while [ $# -gt 0 ]; do
             DEST=$2
             shift 2
             ;;
+        "--clean")
+            CLEAN=yes
+            shift 1
+            ;;
+        "--nodeps")
+            NODEPS=yes
+            shift 1
+            ;;
         *)
             print_usage
             ;;
     esac
 done
 
-if [ -f "$DEST" ]; then
-    rm "$DEST"
+if [ "$CLEAN" = "yes" ]; then
+    rm -rf build
+fi
+
+if [ -z "$NODEPS" ]; then
+    sudo ./install-dependencies.sh
 fi
 
 ./SCYLLA-VERSION-GEN


### PR DESCRIPTION
To build scylla-python3 with 'dist' target of main repo, build_reloc.sh
should take same options with other submodules.

Also added install-dependencies.sh for --nodeps, but leave this empty for now.