### PR TITLE
dist: redhat: reduce log spam from unpacking sources when building rpm

### DIFF
--- a/dist/redhat/python.spec
+++ b/dist/redhat/python.spec
@@ -23,7 +23,7 @@ functionality). All shared libraries needed for the interpreter to
 operate are shipped with it.
 
 %prep
-%setup -n scylla-python3
+%setup -q -n scylla-python3
 
 %install
 ./install.sh --root "$RPM_BUILD_ROOT"


### PR DESCRIPTION
rpmbuild defaults to logging the name of every file it unpacks from
the archive.

Make it quiet with the %setup -q flag.