### PR TITLE
build: support passing product-version-release as a parameter

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -27,6 +27,35 @@ if [ -f build/SCYLLA-RELEASE-FILE ]; then
 	fi
 fi
 
+
+usage() {
+    echo "usage: $0"
+    echo "           [--version product-version-release]          # override p-v-r"
+    exit 1
+}
+
+OVERRIDE=
+while [[ $# > 0 ]]; do
+    case "$1" in
+	--version)
+	    OVERRIDE="$2"
+	    shift 2
+	    ;;
+	*)
+	    usage
+	    ;;
+    esac
+done
+
+if [[ -n "$OVERRIDE" ]]; then
+    # regular expression for p-v-r: alphabetic+dashes for product, trailing non-dashes
+    # for release, everything else for version
+    RE='^([-a-z]+)-(.+)-([^-]+)$'
+    PRODUCT="$(sed -E "s/$RE/\\1/" <<<"$OVERRIDE")"
+    SCYLLA_VERSION="$(sed -E "s/$RE/\\2/" <<<"$OVERRIDE")"
+    SCYLLA_RELEASE="$(sed -E "s/$RE/\\3/" <<<"$OVERRIDE")"
+fi
+
 echo "$SCYLLA_VERSION-$SCYLLA_RELEASE"
 mkdir -p build
 echo "$SCYLLA_VERSION" > build/SCYLLA-VERSION-FILE

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -26,6 +26,7 @@ print_usage() {
     echo "  --dest specify destination path"
     echo "  --clean clean build directory"
     echo "  --nodeps    skip installing dependencies"
+    echo "  --version V  product-version-release string (overriding SCYLLA-VERSION-GEN)"
     exit 1
 }
 
@@ -33,6 +34,7 @@ PACKAGES=
 CLEAN=
 NODEPS=
 DEST=build/scylla-python3-package.tar.gz
+VERSION_OVERRIDE=
 while [ $# -gt 0 ]; do
     case "$1" in
         "--packages")
@@ -51,6 +53,10 @@ while [ $# -gt 0 ]; do
             NODEPS=yes
             shift 1
             ;;
+        "--version")
+            VERSION_OVERRIDE="$2"
+            shift 2
+            ;;
         *)
             print_usage
             ;;
@@ -65,7 +71,7 @@ if [ -z "$NODEPS" ]; then
     sudo ./install-dependencies.sh
 fi
 
-./SCYLLA-VERSION-GEN
+./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"}
 mkdir -p build/python3
 ./dist/debian/debian_files_gen.py
 


### PR DESCRIPTION
Instead of using the baked-in values from SCYLLA-VERSION-GEN,
allow passing an override. This will be used by the supermodule
to have an identical product-version-release (especially release,
which contains the git hash) across all packages.

Note the version number changes from the Python version to the
Scylla version.