### PR TITLE
Fix package naming issues

### DIFF
--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -8,11 +8,10 @@ print_usage() {
     exit 1
 }
 
-PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
-SCYLLA_VERSION=$(cat build/SCYLLA-VERSION-FILE)
-SCYLLA_RELEASE=$(cat build/SCYLLA-RELEASE-FILE)
+DEFAULT_PRODUCT=$(<build/SCYLLA-PRODUCT-FILE || true)
+DEFAULT_PRODUCT=${DEFAULT_PRODUCT:-scylla}
+RELOC_PKG=build/${DEFAULT_PRODUCT}-python3-package.tar.gz
 
-RELOC_PKG=build/$PRODUCT-python3-package.tar.gz
 BUILDDIR=build/debian
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -42,9 +41,11 @@ mkdir -p "$BUILDDIR"/scylla-python3-package
 tar -C "$BUILDDIR"/scylla-python3-package -xpf "$RELOC_PKG"
 cd "$BUILDDIR"/scylla-python3-package
 
-
+PRODUCT=$(cat scylla-python3/SCYLLA-PRODUCT-FILE)
 RELOC_PKG_FULLPATH=$(readlink -f $RELOC_PKG)
 RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
+SCYLLA_VERSION=$(cat scylla-python3/SCYLLA-VERSION-FILE)
+SCYLLA_RELEASE=$(cat scylla-python3/SCYLLA-RELEASE-FILE)
 
 ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-python3_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
 

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -8,7 +8,11 @@ print_usage() {
     exit 1
 }
 
-RELOC_PKG=build/scylla-python3-package.tar.gz
+PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
+SCYLLA_VERSION=$(cat build/SCYLLA-VERSION-FILE)
+SCYLLA_RELEASE=$(cat build/SCYLLA-RELEASE-FILE)
+
+RELOC_PKG=build/$PRODUCT-python3-package.tar.gz
 BUILDDIR=build/debian
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -38,11 +42,9 @@ mkdir -p "$BUILDDIR"/scylla-python3-package
 tar -C "$BUILDDIR"/scylla-python3-package -xpf "$RELOC_PKG"
 cd "$BUILDDIR"/scylla-python3-package
 
-PRODUCT=$(cat scylla-python3/SCYLLA-PRODUCT-FILE)
+
 RELOC_PKG_FULLPATH=$(readlink -f $RELOC_PKG)
 RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
-SCYLLA_VERSION=$(cat scylla-python3/SCYLLA-VERSION-FILE)
-SCYLLA_RELEASE=$(cat scylla-python3/SCYLLA-RELEASE-FILE)
 
 ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-python3_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
 

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -33,7 +33,6 @@ print_usage() {
 PACKAGES=
 CLEAN=
 NODEPS=
-DEST=build/scylla-python3-package.tar.gz
 VERSION_OVERRIDE=
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -75,4 +74,5 @@ fi
 mkdir -p build/python3
 ./dist/debian/debian_files_gen.py
 
+DEST=build/$(<./build/SCYLLA-PRODUCT-FILE)-python3-package.tar.gz
 ./scripts/create-relocatable-package.py --output "$DEST" $PACKAGES

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -7,7 +7,11 @@ print_usage() {
     echo "  --builddir specify rpmbuild directory"
     exit 1
 }
-RELOC_PKG=build/scylla-python3-package.tar.gz
+
+DEFAULT_PRODUCT=$(<build/SCYLLA-PRODUCT-FILE || true)
+DEFAULT_PRODUCT=${DEFAULT_PRODUCT:-scylla}
+RELOC_PKG=build/${DEFAULT_PRODUCT}-python3-package.tar.gz
+
 BUILDDIR=build/redhat
 while [ $# -gt 0 ]; do
     case "$1" in


### PR DESCRIPTION
If we would like to avoid copying this repo for other products with minor changes, we should take into account
the VERSION_OVERRIDE recently added and do our best "guessing" the relocatable package name when
building rpm and deb files.
This mini-series addresses exactly that. This will make it easier to use this repo for other products like scylla-enterprise.
Tested by running the commands and testing the error cases.

Ref scylladb/scylla-pkg#1592