### PR TITLE
Relocatable Package: create product prefixed relocatable archive

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -33,7 +33,6 @@ print_usage() {
 PACKAGES=
 CLEAN=
 NODEPS=
-DEST=build/scylla-python3-package.tar.gz
 VERSION_OVERRIDE=
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -62,6 +61,12 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"})
+# the former command should generate build/SCYLLA-PRODUCT-FILE and some other version
+# related files
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+DEST=build/$PRODUCT-python3-package.tar.gz
 
 if [ "$CLEAN" = "yes" ]; then
     rm -rf build


### PR DESCRIPTION
The build system was hardcoded to produce a package that is
prefixed with scylla instead of the product name. This is not
in line with out CI system requirements and can be also a source
for confusion.
This commit make the packaging system generate a package of
the format: {product}-python3-package.tar.gz instead of
scylla-python3-package.tar.gz