### PR TITLE
dist/debian: handle rc version correctly

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -41,7 +41,7 @@ with open('build/SCYLLA-PRODUCT-FILE') as f:
     product = f.read().strip()
 
 with open('build/SCYLLA-VERSION-FILE') as f:
-    version = f.read().strip()
+    version = f.read().strip().replace('.rc', '~rc').replace('_', '-')
 
 with open('build/SCYLLA-RELEASE-FILE') as f:
     release = f.read().strip()


### PR DESCRIPTION
We need to rename '.rc' to '~rc' on Debian pacakge.