### PR TITLE
dist: debian: adjust .orig tarball name for .rc releases

### DIFF
--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -44,7 +44,7 @@ RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
 SCYLLA_VERSION=$(cat scylla-python3/SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat scylla-python3/SCYLLA-RELEASE-FILE)
 
-ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-python3_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
+ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-python3_${SCYLLA_VERSION/\.rc/~rc}-$SCYLLA_RELEASE.orig.tar.gz
 
 mv scylla-python3/debian debian
 debuild -rfakeroot -us -uc


### PR DESCRIPTION
We rename .rc to ~rc in debian_files_gen.py, but don't do the same
in build_deb.sh, and debuild complains that the .orig tarball name
does not match the version.

We should avoid all the renaming and use ~rc everywhere, but for now,
add an extra renaming pass.

Fixes #12.