### PR TITLE
Add support pip modules

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -23,6 +23,7 @@
 print_usage() {
     echo "build_reloc.sh --dest build/scylla-python3-package.tar.gz"
     echo "  --packages specify python3 packages to be add on relocatable package"
+    echo "  --pip-packages specify pip packages to be add on relocatable package"
     echo "  --dest specify destination path"
     echo "  --clean clean build directory"
     echo "  --nodeps    skip installing dependencies"
@@ -31,6 +32,7 @@ print_usage() {
 }
 
 PACKAGES=
+PIP_PACKAGES=
 CLEAN=
 NODEPS=
 VERSION_OVERRIDE=
@@ -38,6 +40,10 @@ while [ $# -gt 0 ]; do
     case "$1" in
         "--packages")
             PACKAGES="$2"
+            shift 2
+            ;;
+        "--pip-packages")
+            PIP_PACKAGES="$2"
             shift 2
             ;;
         "--dest")
@@ -80,4 +86,4 @@ fi
 mkdir -p build/python3
 ./dist/debian/debian_files_gen.py
 
-./scripts/create-relocatable-package.py --output "$DEST" $PACKAGES
+./scripts/create-relocatable-package.py --output "$DEST" --modules $PACKAGES --pip-modules $PIP_PACKAGES


### PR DESCRIPTION
Since python3-cassandra-driver package dropped from Fedora, we need to
install it from pip.
However, scylla-python3 detects dependencies from rpm, we cannot
add package with pip for relocatable python3.
This implements minimum support of pip module, add package files to
relocatable image.
Currently it does not supported resolve pip package dependencies and
C library dependencies, but this is enough to install cassandra-driver,
since we can install python dependencies from rpm, and able to disable
C extension.

Signed-off-by: Takuya ASADA <syuu@scylladb.com>