### PR TITLE
reloc: add arch to relocatable package filename

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -72,7 +72,7 @@ VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE
 # the former command should generate build/SCYLLA-PRODUCT-FILE and some other version
 # related files
 PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
-DEST=build/$PRODUCT-python3-package.tar.gz
+DEST=build/$PRODUCT-python3-$(arch)-package.tar.gz
 
 if [ "$CLEAN" = "yes" ]; then
     rm -rf build


### PR DESCRIPTION
Add architecture name for relocatable packages, to support distributing
both x86_64 version and aarch64 version.

See scylladb/scylla#8675