### PR TITLE
install.sh: add supervisor support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,7 @@ Options:
   --root /path/to/root     alternative install root (default /)
   --prefix /prefix         directory prefix (default /usr)
   --nonroot                shortcut of '--disttype nonroot'
+  --supervisor             enable supervisor to manage scylla processes
   --help                   this helpful message
 EOF
     exit 1
@@ -37,6 +38,7 @@ EOF
 
 root=/
 nonroot=false
+supervisor=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -50,6 +52,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--nonroot")
             nonroot=true
+            shift 1
+            ;;
+        "--supervisor")
+            supervisor=true
             shift 1
             ;;
         "--help")


### PR DESCRIPTION
Bring supervisor support from dist/docker to install.sh, make it
installable from relocatable package.
This enables to use supervisor with nonroot / offline environment,
and also make relocatable package able to run in Docker environment.

See scylladb/scylla#8849