### PR TITLE
Drop filename start with '..' in pip modules

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -261,6 +261,8 @@ def pip_generate_file_list(package_list):
                 if not location:
                     print(f'Location does not found on pip show -f {pkg}')
                     sys.exit(1)
+                if l.lstrip().startswith('..'):
+                    continue
                 candidates.append(str(pathlib.PurePath(location) / l.lstrip()))
             else:
                 m = re.match(r'^Location:\s(.+)$', l)


### PR DESCRIPTION
On 'geomet' package, package file list contains '../../../bin/geomet',
it causes error while creating tar file because of the relative path.
We just need python library not executables, so let's just skip to add them.