### PR TITLE
reloc: clean up '.orig' temporary directory before building deb package

### DIFF
--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -32,8 +32,7 @@ if [ ! -e $RELOC_PKG ]; then
     exit 1
 fi
 RELOC_PKG=$(readlink -f $RELOC_PKG)
-BUILDDIR=$(readlink -f "$BUILDDIR")
-rm -rf "$BUILDDIR"/scylla-python3-package
+rm -rf "$BUILDDIR"/scylla-python3-package "$BUILDDIR"/scylla-python3-package.orig "$BUILDDIR"/debian
 mkdir -p "$BUILDDIR"/scylla-python3-package
 tar -C "$BUILDDIR"/scylla-python3-package -xpf "$RELOC_PKG"
 cd "$BUILDDIR"/scylla-python3-package


### PR DESCRIPTION
When we terminate the build while building deb package, it may leave
'scylla-package3-package.orig' directory which uses for temporarily
during package build, normally deleted when build finished.
If the directory remains, next deb package build causes error.
So we should remove it when starting the build.

Fixes scylladb/scylla#9264