### PR TITLE
reloc/build_reloc.sh: rename relocatable packages

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -57,10 +57,14 @@ VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE
 # the former command should generate build/SCYLLA-PRODUCT-FILE and some other version
 # related files
 PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
-DEST=build/$PRODUCT-python3-$(arch)-package.tar.gz
+DEST="build/$PRODUCT-python3-$VERSION.$(arch).tar.gz"
 
 if [ "$CLEAN" = "yes" ]; then
     rm -rf build
+fi
+
+if [ -f "$DEST" ]; then
+    rm "$DEST"
 fi
 
 if [ -z "$NODEPS" ]; then


### PR DESCRIPTION
Currently, we use following naming convention for relocatable package
filename:
`  ${package_name}-${arch}-package-${version}.${release}.tar.gz`
But this is very different with Linux standard packaging system such as
.rpm and .deb.
Let's align the convention to .rpm style, so new convention should be:
`  ${package_name}-${version}-${release}.${arch}.tar.gz`

See https://github.com/scylladb/scylla/issues/9799