### PR TITLE
Support installing executables from PIP package

### DIFF
--- a/dist/redhat/python.spec
+++ b/dist/redhat/python.spec
@@ -31,6 +31,9 @@ operate are shipped with it.
 %files
 %dir %{target}
 %{target}/*
+%if %{defined has_bindir}
+%{_bindir}/*
+%endif
 
 %changelog
 

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -9,6 +9,7 @@ print_usage() {
     echo "build_reloc.sh --dest build/scylla-python3-package.tar.gz"
     echo "  --packages specify python3 packages to be add on relocatable package"
     echo "  --pip-packages specify pip packages to be add on relocatable package"
+    echo "  --pip-symlinks specify pip provided commands which need to install to /usr/bin"
     echo "  --dest specify destination path"
     echo "  --clean clean build directory"
     echo "  --nodeps    skip installing dependencies"
@@ -18,6 +19,7 @@ print_usage() {
 
 PACKAGES=
 PIP_PACKAGES=
+PIP_SYMLINKS=
 CLEAN=
 NODEPS=
 VERSION_OVERRIDE=
@@ -29,6 +31,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--pip-packages")
             PIP_PACKAGES="$2"
+            shift 2
+            ;;
+        "--pip-symlinks")
+            PIP_SYMLINKS="$2"
             shift 2
             ;;
         "--dest")
@@ -68,6 +74,7 @@ if [ -z "$NODEPS" ]; then
 fi
 
 ./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"}
+echo "$PIP_SYMLINKS" > build/SCYLLA-PYTHON3-PIP-SYMLINKS-FILE
 mkdir -p build/python3
 ./dist/debian/debian_files_gen.py
 

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -33,13 +33,14 @@ fi
 RELOC_PKG=$(readlink -f $RELOC_PKG)
 RPMBUILD=$(readlink -f $BUILDDIR)
 mkdir -p $BUILDDIR/scylla-python3
-tar -C $BUILDDIR -xpf $RELOC_PKG scylla-python3/SCYLLA-RELOCATABLE-FILE scylla-python3/SCYLLA-RELEASE-FILE scylla-python3/SCYLLA-VERSION-FILE scylla-python3/SCYLLA-PRODUCT-FILE scylla-python3/dist/redhat
+tar -C $BUILDDIR -xpf $RELOC_PKG scylla-python3/SCYLLA-RELOCATABLE-FILE scylla-python3/SCYLLA-RELEASE-FILE scylla-python3/SCYLLA-VERSION-FILE scylla-python3/SCYLLA-PRODUCT-FILE scylla-python3/SCYLLA-PYTHON3-PIP-SYMLINKS-FILE scylla-python3/dist/redhat
 cd $BUILDDIR/scylla-python3
 
 RELOC_PKG_BASENAME=$(basename "$RELOC_PKG")
 SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
 PRODUCT=$(cat SCYLLA-PRODUCT-FILE)
+PIP_SYMLINKS=$(cat SCYLLA-PYTHON3-PIP-SYMLINKS-FILE)
 
 RPMBUILD=$(readlink -f ../)
 mkdir -p "$RPMBUILD"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
@@ -51,6 +52,9 @@ parameters=(
     -D"target /opt/scylladb/python3"
     -D"reloc_pkg $RELOC_PKG_BASENAME"
 )
+if [ -n "$PIP_SYMLINKS" ]; then
+    parameters+=(-D"has_bindir true")
+fi
 
 ln -fv "$RELOC_PKG" "$RPMBUILD"/SOURCES/
 cp dist/redhat/python.spec "$RPMBUILD"/SPECS/

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -19,6 +19,7 @@ import tarfile
 from tempfile import mkstemp
 import magic
 import re
+import collections
 
 
 RELOC_PREFIX='scylla-python3'
@@ -153,10 +154,27 @@ PYTHONPATH="$d/{sitepackages}:$d/{sitepackages64}:$PYTHONPATH" exec -a "$0" "$ld
     ti.linkname = pybin
     ar.reloc_addfile(ti)
 
-def copy_file_to_python_env(ar, f):
+def fixup_shebang(script):
+    obj = io.BytesIO()
+    with open(script) as f:
+        firstline = f.readline()
+        shebang = "#!/usr/bin/env python3\n"
+        obj.write(shebang.encode())
+        for l in f:
+            obj.write(l.encode())
+    obj.seek(0)
+    return obj
+
+def copy_file_to_python_env(ar, f, pip_binfile=False):
     if f.startswith("/usr/bin/python"):
         gen_python_thunk(ar, os.path.basename(f))
         fix_python_binary(ar, f)
+    elif pip_binfile:
+        obj = fixup_shebang(f)
+        ti = tarfile.TarInfo(name=os.path.join("bin", os.path.basename(f)))
+        ti.size = obj.getbuffer().nbytes
+        ti.mode = 0o755
+        ar.reloc_addfile(ti, fileobj=obj)
     else:
         libfile = f
         # python tends to install in both /usr/lib and /usr/lib64, which doesn't mean it is
@@ -244,18 +262,22 @@ def generate_file_list(executables):
 
 def pip_generate_file_list(package_list):
     candidates = []
+    PIPPackageEntry = collections.namedtuple('PIPPackageEntry', ['path', 'binfile'])
     for pkg in package_list:
         pip_info = subprocess.check_output(['pip3','show', '-f', pkg], universal_newlines=True).splitlines()
         location = None
         files_found = False
         for l in pip_info:
+            binfile = False
             if files_found:
                 if not location:
                     print(f'Location does not found on pip show -f {pkg}')
                     sys.exit(1)
-                if l.lstrip().startswith('..'):
-                    continue
-                candidates.append(str(pathlib.PurePath(location) / l.lstrip()))
+                # We need to modify bin files to run in relocatable python3
+                if l.lstrip().startswith('../../../bin/'):
+                    binfile = True
+                e = PIPPackageEntry(str(pathlib.PurePath(location) / l.lstrip()), binfile=binfile)
+                candidates.append(e)
             else:
                 m = re.match(r'^Location:\s(.+)$', l)
                 if m:
@@ -263,7 +285,7 @@ def pip_generate_file_list(package_list):
                 m = re.match(r'^Files:$', l)
                 if m:
                     files_found = True
-    return [x for x in candidates if should_copy(x)]
+    return [x for x in candidates if should_copy(x.path)]
 
 
 ap = argparse.ArgumentParser(description='Create a relocatable python3 interpreter.')
@@ -290,6 +312,7 @@ ar.reloc_add('dist/debian')
 ar.reloc_add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
 ar.reloc_add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
 ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
+ar.reloc_add('build/SCYLLA-PYTHON3-PIP-SYMLINKS-FILE', arcname='SCYLLA-PYTHON3-PIP-SYMLINKS-FILE')
 ar.reloc_add('install.sh')
 ar.reloc_add('build/debian/debian', arcname='debian')
 for p in ['pyhton3-libs'] + packages:
@@ -301,7 +324,7 @@ for p in ['pyhton3-libs'] + packages:
 for f in file_list:
     copy_file_to_python_env(ar, f)
 
-for f in pip_file_list:
-    copy_file_to_python_env(ar, f)
+for e in pip_file_list:
+    copy_file_to_python_env(ar, e.path, e.binfile)
 
 ar.close()


### PR DESCRIPTION
This is v2 of #27.
Changes from v1 is:
 - avoid failing to build .rpm when there is no /usr/bin symlink (which means --pip-symlinks did not passed)
----

Currently, PIP module implementation does not support installing
executables which usually installed at /usr/local/bin/.

To implement installing PIP executables, adding following features:
 - rewrite shebang to #!/usr/bin/env python3
 - generate python thunk for the executable
 - create symlink to /usr/bin

See scylladb/scylla-machine-image#340

Signed-off-by: Takuya ASADA <syuu@scylladb.com>