### PR TITLE
install.sh: drop locale workaround from python3 thunk

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,6 @@ relocate_python3() {
     cat > "$install"<<EOF
 #!/usr/bin/env bash
 [[ -z "\$LD_PRELOAD" ]] || { echo "\$0: not compatible with LD_PRELOAD" >&2; exit 110; }
-export LC_ALL=en_US.UTF-8
 x="\$(readlink -f "\$0")"
 b="\$(basename "\$x")"
 d="\$(dirname "\$x")"


### PR DESCRIPTION
Since #7408 does not occur on current python3 version (3.11.0), let's drop
the workarond.