### PR TITLE
create-relocatable-package: s/pyhton3-libs/python3-libs/

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -318,7 +318,7 @@ ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
 ar.reloc_add('build/SCYLLA-PYTHON3-PIP-SYMLINKS-FILE', arcname='SCYLLA-PYTHON3-PIP-SYMLINKS-FILE')
 ar.reloc_add('install.sh')
 ar.reloc_add('build/debian/debian', arcname='debian')
-for p in ['pyhton3-libs'] + packages:
+for p in ['python3-libs'] + packages:
     pdir = pathlib.Path('/usr/share/licenses/{}/'.format(p))
     if pdir.exists():
         for f in pdir.glob('*'):


### PR DESCRIPTION
pyhton3-libs is apparently a typo. this line of code was not changed since the first day of import of this project.

before this change, python3-libs's LICENSE file is not added to the relocatable tar ball.

after this change, python3-libs's LICENSE file is included in the relocatable tar ball.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>