### PR TITLE
SCYLLA-VERSION-GEN: remove unnecessary bashism

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -35,7 +35,7 @@ usage() {
 }
 
 OVERRIDE=
-while [[ $# > 0 ]]; do
+while [ $# > 0 ]; do
     case "$1" in
 	--version)
 	    OVERRIDE="$2"
@@ -47,7 +47,7 @@ while [[ $# > 0 ]]; do
     esac
 done
 
-if [[ -n "$OVERRIDE" ]]; then
+if [ -n "$OVERRIDE" ]; then
     # regular expression for p-v-r: alphabetic+dashes for product, trailing non-dashes
     # for release, everything else for version
     RE='^([-a-z]+)-(.+)-([^-]+)$'


### PR DESCRIPTION
remove unnecessary bashism, so that this script can be interpreted by a POSIX shell.

/bin/sh is specified in the shebang line. on debian derivatives, /bin/sh is dash, which is POSIX compliant. but this script is written in the bash dialect.

before this change, we could run into following build failure when building the tree on Debian:

[7/904] ./SCYLLA-VERSION-GEN
./SCYLLA-VERSION-GEN: 38: [[: not found

after this change, the build is able to proceed.

closes #25
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>