### PR TITLE
SCYLLA-VERSION-GEN: use -gt when comparing values

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -35,7 +35,7 @@ usage() {
 }
 
 OVERRIDE=
-while [ $# > 0 ]; do
+while [ $# -gt 0 ]; do
     case "$1" in
 	--version)
 	    OVERRIDE="$2"


### PR DESCRIPTION
in https://github.com/ceph/scylla-python3/commit/2ef2ea0570f02bc38a8349a8b52cc06ffd2964df, `if [[ condition ]]`
was replaced with `if [ ]`, so that this syntax is POSIX compliant
and can be interpreted by shells like dash which is used by Debian
derivatives.

but unforuntately, without "[[ ]], "n > m" is interpreted as a redirect
operation, which redirect the output from a fd of n to file named "m".
but what we expect is to compare two integers.

before this change, the SCYLLA-VERSION-GEN is likely to fail, as the
redirect operation always succeeds unless the destination file is not
writable. no matter what the result is assured to equal to the result
of "n < m".

after this change, we compare the numbers using "-gt", which is standard
compliant and the result is expected. see also
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html .

this change should address the regression introduced by
https://github.com/ceph/scylla-python3/commit/2ef2ea0570f02bc38a8349a8b52cc06ffd2964df

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>