### PR TITLE
build_reloc: do not run SCYLLA-VERSION-GEN twice

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -59,25 +59,23 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"})
-# the former command should generate build/SCYLLA-PRODUCT-FILE and some other version
-# related files
-PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
-DEST="build/$PRODUCT-python3-$VERSION.$(arch).tar.gz"
-
 if [ "$CLEAN" = "yes" ]; then
     rm -rf build
-fi
-
-if [ -f "$DEST" ]; then
-    rm "$DEST"
 fi
 
 if [ -z "$NODEPS" ]; then
     sudo ./install-dependencies.sh
 fi
 
-./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"}
+VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"})
+# the former command should generate build/SCYLLA-PRODUCT-FILE and some other version
+# related files
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+DEST="build/$PRODUCT-python3-$VERSION.$(arch).tar.gz"
+if [ -f "$DEST" ]; then
+    rm "$DEST"
+fi
+
 echo "$PIP_SYMLINKS" > build/SCYLLA-PYTHON3-PIP-SYMLINKS-FILE
 mkdir -p build/python3
 ./dist/debian/debian_files_gen.py


### PR DESCRIPTION
reloc/build_reloc.sh uses this script for preparing the p-v-r files, and also for the version string. but it do this twice, the first time it gets the VERSION string and generate the p-v-r files. and the second time, it get the identical files. there is no need to execute the script twice.

so, in this change, we just drop the second call, and adjust the order of the cleanups to ensure the data dependency. this should help us avoid the echoed version in stdout when packaging the python3 environment.